### PR TITLE
Compatibility with Windows.

### DIFF
--- a/Network/Socks5.hs
+++ b/Network/Socks5.hs
@@ -55,7 +55,7 @@ socksConnectAddr sock sockserver destaddr = withSocks sock sockserver $ do
 	case destaddr of
 		SockAddrInet p h      -> socks5ConnectIPV4 sock h p >> return ()
 		SockAddrInet6 p _ h _ -> socks5ConnectIPV6 sock h p >> return ()
-		SockAddrUnix _        -> error "unsupported unix sockaddr type"
+		_                     -> error "unsupported unix sockaddr type"
 
 -- | connect a new socket to the socks server, and connect the stream to a FQDN
 -- resolved on the server side.


### PR DESCRIPTION
This is basically an ugly hack: since you're ignoring SockAddrUnix constructor anyway, just don't use its name. This will give a warning on Windows about overlapping patterns, but it's better than the compile failing.

If you could release this ASAP, I'd appreciate it. There's a lot of urgency coming from @akaspin in snoyberg/http-conduit#11
