### PR TITLE
Avoid declaring doc files as runtime data files

### DIFF
--- a/socks.cabal
+++ b/socks.cabal
@@ -12,7 +12,7 @@ Category:            Network
 stability:           experimental
 Cabal-Version:       >=1.6
 Homepage:            http://github.com/vincenthz/hs-socks
-data-files:          README.md, Example.hs
+extra-doc-files:     README.md, Example.hs
 
 Library
   Build-Depends:     base >= 3 && < 5


### PR DESCRIPTION
`README.md` and `Example.hs` are not required as a runtime data files.
