### PR TITLE
Update source repository to use https

### DIFF
--- a/socks.cabal
+++ b/socks.cabal
@@ -32,4 +32,4 @@ Library
 
 source-repository head
   type: git
-  location: git://github.com/vincenthz/hs-socks
+  location: https://github.com/vincenthz/hs-socks


### PR DESCRIPTION
`git://` is no longer supported.